### PR TITLE
Draft: Optimize csrsv

### DIFF
--- a/library/src/level2/csrsv_device.h
+++ b/library/src/level2/csrsv_device.h
@@ -359,6 +359,12 @@ __device__ void csrsv_device(J m,
 {
     int lid = hipThreadIdx_x & (WF_SIZE - 1);
     int wid = hipThreadIdx_x / WF_SIZE;
+    if(WF_SIZE == warpSize)
+    {
+        // Scalarize wid, i.e. move it from a vector register to a scalar register, so all
+        // dependent values can be loaded or computed with scalar instructions (idx, row_begin...)
+        wid = __builtin_amdgcn_readfirstlane(wid);
+    }
 
     // Index into the row map
     J idx = hipBlockIdx_x * (BLOCKSIZE / WF_SIZE) + wid;


### PR DESCRIPTION
Summary of proposed changes:
- "Optimize csrsv: scalarize wid" helps the compiler generate faster code. When `wid` is a scalar value (and pointers are const and restricted), it is possible to use scalar loads instead of vector loads for row, row_begin, row_end.
(Perhaps it's better to wrap it as a template function).
With this change we observe -5% of csrsv_kernel's duration in one application.
- "Optimize csrsv: pack "done" flags (32 per uint)" reduces the amount of memory to load when some lanes depend on neighboring rows so they can load one common uint instead of unique uints. Also less memory (32x) is need to be cleared.
About -15% of csrsv_kernel's duration in one application.

All changes are independent, I can split them into separate PR if you want.

